### PR TITLE
Propose a better error message for failed parsing

### DIFF
--- a/src/secrets.cr
+++ b/src/secrets.cr
@@ -3,8 +3,8 @@ require "yaml"
 
 class Secrets
   AES_BITS = 256
-  KEY_SIZE = 32
-  IV_SIZE = 32
+  KEY_SIZE =  32
+  IV_SIZE  =  32
 
   class_getter stores : Hash(String, Secrets) = Hash(String, Secrets).new
   class_property default_stores_dir : Path = Path["./secrets"]
@@ -32,13 +32,12 @@ class Secrets
     key = @encryption_key.as_slice
     data = data[IV_SIZE..]
     @aes = AES.new(key, iv, AES_BITS)
-    decrypted = String.new(@aes.decrypt(data))
     begin
-      yaml = YAML.parse(decrypted)
-    rescue ex : YAML::ParseException
-      puts "Invalid YAML: #{ex.message}"
-      raise "YAML::ParseException: This could be due to an invalid key, bad encoding on the key or secrets file, or just bad yaml!"
+      decrypted = String.new(@aes.decrypt(data))
+    rescue ex : AES::Error
+      raise "AES::Error: Failed to decrypt the data, this can be due to an invalid key or bad encoding on the key or secrets file"
     end
+    yaml = YAML.parse(decrypted)
     @data = yaml.as_h.map { |k, v| [k.to_s, v.to_s] }.to_h
   end
 

--- a/src/secrets.cr
+++ b/src/secrets.cr
@@ -35,8 +35,9 @@ class Secrets
     decrypted = String.new(@aes.decrypt(data))
     begin
       yaml = YAML.parse(decrypted)
-    rescue YAML::ParseException
-      raise "Invalid YAML: This could be due to an invalid key, bad encoding on the key or secrets file, or just bad yaml!"
+    rescue ex : YAML::ParseException
+      puts "Invalid YAML: #{ex.message}"
+      raise "YAML::ParseException: This could be due to an invalid key, bad encoding on the key or secrets file, or just bad yaml!"
     end
     @data = yaml.as_h.map { |k, v| [k.to_s, v.to_s] }.to_h
   end

--- a/src/secrets.cr
+++ b/src/secrets.cr
@@ -33,7 +33,11 @@ class Secrets
     data = data[IV_SIZE..]
     @aes = AES.new(key, iv, AES_BITS)
     decrypted = String.new(@aes.decrypt(data))
-    yaml = YAML.parse(decrypted)
+    begin
+      yaml = YAML.parse(decrypted)
+    rescue YAML::ParseException
+      raise "Invalid YAML: This could be due to an invalid key, bad encoding on the key or secrets file, or just bad yaml!"
+    end
     @data = yaml.as_h.map { |k, v| [k.to_s, v.to_s] }.to_h
   end
 


### PR DESCRIPTION
As of now, failing to parse the data can result in wild error messages.
Such as "Invalid trailing character" "Invalid control character", etc.

These errors can occur if there is an invalid key to decrypt the data, or even perhaps invalid encoding on the secrets or key file.

This proposes a general error message of "Your key may be wrong, encoding might be messed up, or you just have crap YAML"
This also prints out the original error message in the rare occasion that is in fact, crap YAML.